### PR TITLE
Fix rare fail of npc_dashel_stonefistAI end phase.

### DIFF
--- a/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/stormwind_city.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/stormwind_city.cpp
@@ -137,7 +137,7 @@ struct npc_dashel_stonefistAI : public ScriptedAI
     {
         if (m_uiStartEventTimer)
         {
-            if (m_uiStartEventTimer < uiDiff)
+            if (m_uiStartEventTimer <= uiDiff)
             {
                 if (Player* pPlayer = m_creature->GetMap()->GetPlayer(m_playerGuid))
                 {
@@ -158,7 +158,7 @@ struct npc_dashel_stonefistAI : public ScriptedAI
 
         if (m_uiEndEventTimer)
         {
-            if (m_uiEndEventTimer < uiDiff)
+            if (m_uiEndEventTimer <= uiDiff)
             {
                 DoScriptText(SAY_STONEFIST_3, m_creature);
 


### PR DESCRIPTION
m_uiStartEventTimer & m_uiEndEventTimer related conditions in UpdateAI have a boundary logic problem. 
if m_uiStartEventTimer == uiDiff exactly at one server tick, then the m_uiStartEventTimer will result in a certain 0 value at the very next server tick. 
This will cause a rare false on the if (m_uiStartEventTimer) check at the beginning of UpdateAI() and lead to the related quest cannot start. 
So as the m_uiEndEventTimer will lead to a cannot end.

## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
